### PR TITLE
Update GO Shiny Banlist (#2808)

### DIFF
--- a/PKHeX.Core/Legality/Tables/Tables7b.cs
+++ b/PKHeX.Core/Legality/Tables/Tables7b.cs
@@ -301,8 +301,6 @@ namespace PKHeX.Core
             085, // Dodrio
             100, // Voltorb
             101, // Electrode
-            102, // Exeggcute
-            103, // Exeggutor
             106, // Hitmonlee
             107, // Hitmonchan
             114, // Tangela


### PR DESCRIPTION
Fork update

Forgot to update when the Easter event began. Removes Shiny Exeggcute/Exeggutor.